### PR TITLE
feat!: add `defineConfigObject` and ref writeback

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -132,7 +132,7 @@ export default defineConfig({
           if (!id.endsWith('.md'))
             return
           return code.replace(/`(\w+)::([^(`]+)(\(\S+?\))?`/g, (_, scope, name, link) => {
-            return `<ApiLink scope="${scope}" name="${name}" ${link ? `link="${link}"` : ''}/>`
+            return `<ApiLink scope="${scope}" name="${name}" ${link ? `link="${link.slice(1, -1)}"` : ''}/>`
           })
         },
       },

--- a/docs/guide/config.md
+++ b/docs/guide/config.md
@@ -32,7 +32,9 @@ Visit the [official documentation](https://code.visualstudio.com/api/references/
 
 ## Use in Extension
 
-To use the settings in the extension, you can use the `reactive::defineConfigs` function to define the configuration. The following code is corresponding to the above configuration.
+To use the settings in the extension, you can use the `reactive::defineConfigs` or `reactive::defineConfigObject` function to define the configuration. The following examples are corresponding to the above configuration.
+
+### As Refs
 
 ```ts
 import { defineConfigs } from 'reactive-vscode'
@@ -45,8 +47,9 @@ const { enable, greeting } = defineConfigs('your-extension', {
 
 Note that you should always set the default value in the manifest file. `reactive::defineConfigs` does not provide default values.
 
-In the above example, `enable` is of type `ConfigRef<boolean>`, which extends `Ref<boolean>`. Note that setting `enable.value` will not update the configuration. You should use `enable.update` instead.
+In the above example, `enable` is of type `ConfigRef<boolean>`, which extends `Ref<boolean>`.
 
+<!-- eslint-disable import/first -->
 ```ts
 import { defineConfigs } from 'reactive-vscode'
 
@@ -55,11 +58,67 @@ const { enable, greeting } = defineConfigs('your-extension', {
   greeting: [String, null],
 })
 // ---cut---
-// This will not update the configuration. Only the value in the memory is changed.
-enable.value = false
+import { ConfigurationTarget } from 'vscode'
 
 // This will write the value back to the configuration.
-enable.update(false)
+enable.value = false
+
+// To pass the rest of the options, you can use the `update` method.
+enable.update(false, ConfigurationTarget.Global)
 ```
 
-The `update` method also accepts `configurationTarget` and `overrideInLanguage` options. Visit the [official documentation](https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration.update) for more information.
+Visit the [official documentation](https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration.update) for more information about the rest of the options.
+
+### As an Object
+
+```ts
+import { defineConfigObject } from 'reactive-vscode'
+
+const config = defineConfigObject('your-extension', {
+  enable: Boolean,
+  greeting: [String, null],
+})
+```
+
+In the above example, `config` is a `vue::ShallowReactive(https://cn.vuejs.org/api/reactivity-advanced.html#shallowreactive)` object.
+
+<!-- eslint-disable import/first -->
+```ts
+import { defineConfigObject } from 'reactive-vscode'
+
+const config = defineConfigObject('your-extension', {
+  enable: Boolean,
+  greeting: [String, null],
+})
+// ---cut---
+import { ConfigurationTarget } from 'vscode'
+
+// This will write the value back to the configuration.
+config.enable = false
+
+// To pass the rest of the options, you can use the `$update` method.
+config.$update('enable', false, ConfigurationTarget.Global)
+```
+
+Visit the [official documentation](https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration.update) for more information about the rest of the options.
+
+## Use with `vscode-ext-gen`
+
+You can also use the [`vscode-ext-gen`](https://github.com/antfu/vscode-ext-gen) to generate the configuration settings. For example:
+
+```ts
+import { defineConfigObject, defineConfigs, reactive, ref } from 'reactive-vscode'
+import { type ScopedConfigKeyTypeMap, scopedConfigs } from './generated-meta'
+
+const { disabled } = defineConfigs<ScopedConfigKeyTypeMap>(
+  scopedConfigs.scope,
+  scopedConfigs.defaults,
+)
+
+// Or
+
+const config = defineConfigObject<ScopedConfigKeyTypeMap>(
+  scopedConfigs.scope,
+  scopedConfigs.defaults,
+)
+```

--- a/docs/snippets/generated-meta.ts
+++ b/docs/snippets/generated-meta.ts
@@ -1,0 +1,19 @@
+export interface ScopedConfigKeyTypeMap {
+  disabled: boolean
+  autoDetection: boolean
+  localesPaths: undefined
+  encoding: string
+}
+
+export const scopedConfigs = {
+  scope: 'i18n-ally',
+  defaults: {
+    disabled: false,
+    autoDetection: true,
+    localesPaths: undefined,
+    encoding: 'utf-8',
+    // ...
+  },
+}
+
+// ...

--- a/packages/core/src/utils/defineConfigObject.ts
+++ b/packages/core/src/utils/defineConfigObject.ts
@@ -1,13 +1,12 @@
 import type { ShallowReactive } from '@reactive-vscode/reactivity'
 import { shallowReactive } from '@reactive-vscode/reactivity'
 import type { ConfigurationScope, ConfigurationTarget } from 'vscode'
-import { workspace } from 'vscode'
-import { useDisposable } from '../composables'
-import { onActivate } from './onActivate'
+import type { ConfigTypeOptions, ParseConfigTypeOptions } from './defineConfigs'
+import { defineConfigs } from './defineConfigs'
 import type { Nullable } from './types'
 
-type ConfigObject<C extends object> = ShallowReactive<C & {
-  $update: (key: keyof C, value: C[keyof C], configurationTarget?: ConfigurationTarget | boolean | null, overrideInLanguage?: boolean) => Promise<void>
+export type ConfigObject<C extends object> = ShallowReactive<C & {
+  $update: (key: keyof C, value: C[keyof C], configurationTarget?: Nullable<ConfigurationTarget>, overrideInLanguage?: boolean) => Promise<void>
 }>
 
 /**
@@ -17,40 +16,15 @@ type ConfigObject<C extends object> = ShallowReactive<C & {
  *
  * @category lifecycle
  */
-export function defineConfigObject<const C extends object>(
-  section: string,
-  defaults: C,
-  scope?: Nullable<ConfigurationScope>,
-): ConfigObject<C> {
-  const workspaceConfig = workspace.getConfiguration(section, scope)
+export function defineConfigObject<const C extends ConfigTypeOptions>(section: string, configs: C, scope?: Nullable<ConfigurationScope>): ConfigObject<ParseConfigTypeOptions<C>>
+export function defineConfigObject<C extends object>(section: string, configs: C, scope?: Nullable<ConfigurationScope>): ConfigObject<C>
+export function defineConfigObject(section: string, configs: Record<string, unknown>, scope?: Nullable<ConfigurationScope>) {
+  const configRefs = defineConfigs(section, configs, scope)
 
-  const keys = Object.keys(defaults)
-
-  const initialConfigs = Object.fromEntries(
-    keys.map((key) => {
-      return [key, workspaceConfig.get(key)]
-    }),
-  ) as C
-
-  const configObject = shallowReactive({
-    ...initialConfigs,
-    $update: async (key, value, configurationTarget, overrideInLanguage) => {
-      configObject[key] = value as any
-      await workspaceConfig.update(key as string, value, configurationTarget, overrideInLanguage)
+  return shallowReactive({
+    ...configRefs,
+    $update(key, value, configurationTarget, overrideInLanguage) {
+      return configRefs[key].update(value, configurationTarget, overrideInLanguage)
     },
-  }) as ConfigObject<C>
-
-  onActivate(() => {
-    useDisposable(workspace.onDidChangeConfiguration((e) => {
-      if (!e.affectsConfiguration(section))
-        return
-      const newWorkspaceConfig = workspace.getConfiguration(section)
-      for (const key in keys) {
-        if (e.affectsConfiguration(`${section}.${key}`))
-          configObject[key as keyof C] = newWorkspaceConfig.get(key) as any
-      }
-    }))
-  })
-
-  return configObject
+  }) satisfies ConfigObject<typeof configs>
 }

--- a/packages/core/src/utils/defineConfigObject.ts
+++ b/packages/core/src/utils/defineConfigObject.ts
@@ -6,6 +6,11 @@ import { defineConfigs } from './defineConfigs'
 import type { Nullable } from './types'
 
 export type ConfigObject<C extends object> = ShallowReactive<C & {
+  /**
+   * Write the configuration value to the workspace.
+   *
+   * @see https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration.update
+   */
   $update: (key: keyof C, value: C[keyof C], configurationTarget?: Nullable<ConfigurationTarget>, overrideInLanguage?: boolean) => Promise<void>
 }>
 

--- a/packages/core/src/utils/defineConfigObject.ts
+++ b/packages/core/src/utils/defineConfigObject.ts
@@ -1,0 +1,56 @@
+import type { ShallowReactive } from '@reactive-vscode/reactivity'
+import { shallowReactive } from '@reactive-vscode/reactivity'
+import type { ConfigurationScope, ConfigurationTarget } from 'vscode'
+import { workspace } from 'vscode'
+import { useDisposable } from '../composables'
+import { onActivate } from './onActivate'
+import type { Nullable } from './types'
+
+type ConfigObject<C extends object> = ShallowReactive<C & {
+  $update: (key: keyof C, value: C[keyof C], configurationTarget?: ConfigurationTarget | boolean | null, overrideInLanguage?: boolean) => Promise<void>
+}>
+
+/**
+ * Define configurations of an extension. See `vscode::workspace.getConfiguration`.
+ *
+ * You can use this function with [vscode-ext-gen](https://github.com/antfu/vscode-ext-gen).
+ *
+ * @category lifecycle
+ */
+export function defineConfigObject<const C extends object>(
+  section: string,
+  defaults: C,
+  scope?: Nullable<ConfigurationScope>,
+): ConfigObject<C> {
+  const workspaceConfig = workspace.getConfiguration(section, scope)
+
+  const keys = Object.keys(defaults)
+
+  const initialConfigs = Object.fromEntries(
+    keys.map((key) => {
+      return [key, workspaceConfig.get(key)]
+    }),
+  ) as C
+
+  const configObject = shallowReactive({
+    ...initialConfigs,
+    $update: async (key, value, configurationTarget, overrideInLanguage) => {
+      configObject[key] = value as any
+      await workspaceConfig.update(key as string, value, configurationTarget, overrideInLanguage)
+    },
+  }) as ConfigObject<C>
+
+  onActivate(() => {
+    useDisposable(workspace.onDidChangeConfiguration((e) => {
+      if (!e.affectsConfiguration(section))
+        return
+      const newWorkspaceConfig = workspace.getConfiguration(section)
+      for (const key in keys) {
+        if (e.affectsConfiguration(`${section}.${key}`))
+          configObject[key as keyof C] = newWorkspaceConfig.get(key) as any
+      }
+    }))
+  })
+
+  return configObject
+}

--- a/packages/core/src/utils/defineConfigs.ts
+++ b/packages/core/src/utils/defineConfigs.ts
@@ -14,39 +14,46 @@ const ConfigTypeSymbol = Symbol('ConfigType')
 export interface ConfigType<T> extends ObjectConstructor {
   [ConfigTypeSymbol]: T
 }
-type ConfigTypeSingle<T> = string | typeof String | typeof Number | typeof Boolean | typeof Array | typeof Object | null | ConfigType<T>
+type ConfigTypeSingle<T> = typeof String | typeof Number | typeof Boolean | typeof Array | typeof Object | null | ConfigType<T>
 type ConfigTypeRaw<T> = ConfigTypeSingle<T> | ConfigTypeSingle<T>[]
-type ConfigTypeOptions = Record<string, ConfigTypeRaw<any>>
+
+/**
+ * @internal
+ */
+export type ConfigTypeOptions = Record<string, ConfigTypeRaw<any>>
 
 type ParseConfigType<C extends ConfigTypeRaw<any>> =
-  C extends string ? (
-    C extends 'string' ? string :
-      C extends 'number' ? number :
-        C extends 'boolean' ? boolean :
-          C extends 'null' ? null :
-            C extends 'integer' ? number :
-              C extends 'array' ? any[] :
-                C extends 'object' ? Record<string | number, any> : never
-  )
-    : C extends (infer C1)[] ? (C1 extends ConfigTypeSingle<any> ? ParseConfigType<C1> : never)
-      : C extends ConfigType<infer T> ? T : (
-        C extends typeof String ? string :
-          C extends typeof Number ? number :
-            C extends typeof Boolean ? boolean :
-              C extends typeof Array ? any[] :
-                C extends typeof Object ? Record<string | number, any> :
-                  C extends null ? null : never
-      )
-type ParseConfigTypeOptions<C extends ConfigTypeOptions> = {
-  [K in keyof C]: ConfigRef<ParseConfigType<C[K]>>
+  C extends (infer C1)[] ? (C1 extends ConfigTypeSingle<any> ? ParseConfigType<C1> : never)
+    : C extends ConfigType<infer T> ? T : (
+      C extends typeof String ? string :
+        C extends typeof Number ? number :
+          C extends typeof Boolean ? boolean :
+            C extends typeof Array ? any[] :
+              C extends typeof Object ? Record<string | number, any> :
+                C extends null ? null : never
+    )
+
+/**
+ * @internal
+ */
+export type ParseConfigTypeOptions<C extends ConfigTypeOptions> = {
+  [K in keyof C]: ParseConfigType<C[K]>
+}
+
+type ToConfigRefs<C extends object> = {
+  [K in keyof C]: ConfigRef<C[K]>
 }
 
 /**
  * Define configurations of an extension. See `vscode::workspace.getConfiguration`.
  *
+ * You can use this function with [vscode-ext-gen](https://github.com/antfu/vscode-ext-gen).
+ *
  * @category lifecycle
  */
-export function defineConfigs<const C extends ConfigTypeOptions>(section: string, configs: C, scope?: Nullable<ConfigurationScope>): ParseConfigTypeOptions<C> {
+export function defineConfigs<const C extends ConfigTypeOptions>(section: string, configs: C, scope?: Nullable<ConfigurationScope>): ToConfigRefs<ParseConfigTypeOptions<C>>
+export function defineConfigs<C extends object>(section: string, configs: C, scope?: Nullable<ConfigurationScope>): ToConfigRefs<C>
+export function defineConfigs(section: string, configs: object, scope?: Nullable<ConfigurationScope>) {
   const workspaceConfig = workspace.getConfiguration(section, scope)
 
   function createConfigRef<T>(key: string, value: T): ConfigRef<T> {
@@ -62,7 +69,7 @@ export function defineConfigs<const C extends ConfigTypeOptions>(section: string
     Object.keys(configs).map((key) => {
       return [key, createConfigRef(key, workspaceConfig.get(key))]
     }),
-  ) as ParseConfigTypeOptions<C>
+  )
 
   onActivate(() => {
     useDisposable(workspace.onDidChangeConfiguration((e) => {

--- a/packages/core/src/utils/defineConfigs.ts
+++ b/packages/core/src/utils/defineConfigs.ts
@@ -1,6 +1,6 @@
 import type { ShallowRef } from '@reactive-vscode/reactivity'
-import { shallowRef } from '@reactive-vscode/reactivity'
-import type { ConfigurationScope, ConfigurationTarget } from 'vscode'
+import { computed, shallowRef } from '@reactive-vscode/reactivity'
+import type { ConfigurationScope, ConfigurationTarget, WorkspaceConfiguration } from 'vscode'
 import { workspace } from 'vscode'
 import { useDisposable } from '../composables'
 import { onActivate } from './onActivate'
@@ -40,6 +40,49 @@ type ParseConfigTypeOptions<C extends ConfigTypeOptions> = {
   [K in keyof C]: ConfigRef<ParseConfigType<C[K]>>
 }
 
+function _createConfigRef<T>(workspaceConfig: WorkspaceConfiguration, key: string, value: T): ConfigRef<T> {
+  const data = shallowRef(value)
+
+  async function update(value: T, configurationTarget?: ConfigurationTarget | boolean | null, overrideInLanguage?: boolean) {
+    data.value = value
+    await workspaceConfig.update(key, value, configurationTarget, overrideInLanguage)
+  }
+
+  const ref = computed({
+    get() {
+      return data.value
+    },
+    set(v) {
+      data.value = v
+      update(v)
+    },
+  }) as unknown as ConfigRef<T>
+
+  ref.update = update
+
+  // @ts-expect-error internal function
+  ref._set = (v: T) => {
+    data.value = v
+  }
+
+  return ref
+}
+
+export function createConfigRef<T>(key: string, value: T): ConfigRef<T> {
+  const ref = _createConfigRef(workspace.getConfiguration(), key, value)
+
+  onActivate(() => {
+    useDisposable(workspace.onDidChangeConfiguration((e) => {
+      if (!e.affectsConfiguration(key))
+        return
+      // @ts-expect-error internal function
+      ref._set(workspace.getConfiguration().get(key))
+    }))
+  })
+
+  return ref
+}
+
 /**
  * Define configurations of an extension. See `vscode::workspace.getConfiguration`.
  *
@@ -48,18 +91,9 @@ type ParseConfigTypeOptions<C extends ConfigTypeOptions> = {
 export function defineConfigs<const C extends ConfigTypeOptions>(section: string, configs: C, scope?: ConfigurationScope | null | undefined): ParseConfigTypeOptions<C> {
   const workspaceConfig = workspace.getConfiguration(section, scope)
 
-  function createConfigRef<T>(key: string, value: T): ConfigRef<T> {
-    const ref = shallowRef(value) as unknown as ConfigRef<T>
-    ref.update = async (value, configurationTarget, overrideInLanguage) => {
-      await workspaceConfig.update(key, value, configurationTarget, overrideInLanguage)
-      ref.value = value
-    }
-    return ref
-  }
-
   const configRefs = Object.fromEntries(
     Object.keys(configs).map((key) => {
-      return [key, createConfigRef(key, workspaceConfig.get(key))]
+      return [key, _createConfigRef(workspaceConfig, key, workspaceConfig.get(key))]
     }),
   ) as ParseConfigTypeOptions<C>
 
@@ -70,7 +104,42 @@ export function defineConfigs<const C extends ConfigTypeOptions>(section: string
       const newWorkspaceConfig = workspace.getConfiguration(section)
       for (const key in configs) {
         if (e.affectsConfiguration(`${section}.${key}`))
-          configRefs[key].value = newWorkspaceConfig.get(key) as any
+          // @ts-expect-error internal function
+          configRefs[key]._set(newWorkspaceConfig.get(key))
+      }
+    }))
+  })
+
+  return configRefs
+}
+
+/**
+ * Define configurations of an extension. See `vscode::workspace.getConfiguration`.
+ *
+ * @category lifecycle
+ */
+export function defineConfigsWithDefaults<const C extends object>(
+  section: string,
+  defaults: C,
+  scope?: ConfigurationScope | null | undefined,
+): { [K in keyof C]: ConfigRef<C[K]> } {
+  const workspaceConfig = workspace.getConfiguration(section, scope)
+
+  const configRefs = Object.fromEntries(
+    Object.entries(defaults).map(([key, value]) => {
+      return [key, _createConfigRef(workspaceConfig, key, value)]
+    }),
+  ) as { [K in keyof C]: ConfigRef<C[K]> }
+
+  onActivate(() => {
+    useDisposable(workspace.onDidChangeConfiguration((e) => {
+      if (!e.affectsConfiguration(section))
+        return
+      const newWorkspaceConfig = workspace.getConfiguration(section)
+      for (const key in defaults) {
+        if (e.affectsConfiguration(`${section}.${key}`))
+          // @ts-expect-error internal function
+          configRefs[key]._set(newWorkspaceConfig.get(key))
       }
     }))
   })

--- a/packages/core/src/utils/defineConfigs.ts
+++ b/packages/core/src/utils/defineConfigs.ts
@@ -1,9 +1,10 @@
 import type { ShallowRef } from '@reactive-vscode/reactivity'
-import { computed, shallowRef } from '@reactive-vscode/reactivity'
-import type { ConfigurationScope, ConfigurationTarget, WorkspaceConfiguration } from 'vscode'
+import { shallowRef } from '@reactive-vscode/reactivity'
+import type { ConfigurationScope, ConfigurationTarget } from 'vscode'
 import { workspace } from 'vscode'
 import { useDisposable } from '../composables'
 import { onActivate } from './onActivate'
+import type { Nullable } from './types'
 
 export interface ConfigRef<T> extends ShallowRef<T> {
   update: (value: T, configurationTarget?: ConfigurationTarget | boolean | null, overrideInLanguage?: boolean) => Promise<void>
@@ -40,60 +41,26 @@ type ParseConfigTypeOptions<C extends ConfigTypeOptions> = {
   [K in keyof C]: ConfigRef<ParseConfigType<C[K]>>
 }
 
-function _createConfigRef<T>(workspaceConfig: WorkspaceConfiguration, key: string, value: T): ConfigRef<T> {
-  const data = shallowRef(value)
-
-  async function update(value: T, configurationTarget?: ConfigurationTarget | boolean | null, overrideInLanguage?: boolean) {
-    data.value = value
-    await workspaceConfig.update(key, value, configurationTarget, overrideInLanguage)
-  }
-
-  const ref = computed({
-    get() {
-      return data.value
-    },
-    set(v) {
-      data.value = v
-      update(v)
-    },
-  }) as unknown as ConfigRef<T>
-
-  ref.update = update
-
-  // @ts-expect-error internal function
-  ref._set = (v: T) => {
-    data.value = v
-  }
-
-  return ref
-}
-
-export function createConfigRef<T>(key: string, value: T): ConfigRef<T> {
-  const ref = _createConfigRef(workspace.getConfiguration(), key, value)
-
-  onActivate(() => {
-    useDisposable(workspace.onDidChangeConfiguration((e) => {
-      if (!e.affectsConfiguration(key))
-        return
-      // @ts-expect-error internal function
-      ref._set(workspace.getConfiguration().get(key))
-    }))
-  })
-
-  return ref
-}
-
 /**
  * Define configurations of an extension. See `vscode::workspace.getConfiguration`.
  *
  * @category lifecycle
  */
-export function defineConfigs<const C extends ConfigTypeOptions>(section: string, configs: C, scope?: ConfigurationScope | null | undefined): ParseConfigTypeOptions<C> {
+export function defineConfigs<const C extends ConfigTypeOptions>(section: string, configs: C, scope?: Nullable<ConfigurationScope>): ParseConfigTypeOptions<C> {
   const workspaceConfig = workspace.getConfiguration(section, scope)
+
+  function createConfigRef<T>(key: string, value: T): ConfigRef<T> {
+    const ref = shallowRef(value) as unknown as ConfigRef<T>
+    ref.update = async (value, configurationTarget, overrideInLanguage) => {
+      await workspaceConfig.update(key, value, configurationTarget, overrideInLanguage)
+      ref.value = value
+    }
+    return ref
+  }
 
   const configRefs = Object.fromEntries(
     Object.keys(configs).map((key) => {
-      return [key, _createConfigRef(workspaceConfig, key, workspaceConfig.get(key))]
+      return [key, createConfigRef(key, workspaceConfig.get(key))]
     }),
   ) as ParseConfigTypeOptions<C>
 
@@ -104,42 +71,7 @@ export function defineConfigs<const C extends ConfigTypeOptions>(section: string
       const newWorkspaceConfig = workspace.getConfiguration(section)
       for (const key in configs) {
         if (e.affectsConfiguration(`${section}.${key}`))
-          // @ts-expect-error internal function
-          configRefs[key]._set(newWorkspaceConfig.get(key))
-      }
-    }))
-  })
-
-  return configRefs
-}
-
-/**
- * Define configurations of an extension. See `vscode::workspace.getConfiguration`.
- *
- * @category lifecycle
- */
-export function defineConfigsWithDefaults<const C extends object>(
-  section: string,
-  defaults: C,
-  scope?: ConfigurationScope | null | undefined,
-): { [K in keyof C]: ConfigRef<C[K]> } {
-  const workspaceConfig = workspace.getConfiguration(section, scope)
-
-  const configRefs = Object.fromEntries(
-    Object.entries(defaults).map(([key, value]) => {
-      return [key, _createConfigRef(workspaceConfig, key, value)]
-    }),
-  ) as { [K in keyof C]: ConfigRef<C[K]> }
-
-  onActivate(() => {
-    useDisposable(workspace.onDidChangeConfiguration((e) => {
-      if (!e.affectsConfiguration(section))
-        return
-      const newWorkspaceConfig = workspace.getConfiguration(section)
-      for (const key in defaults) {
-        if (e.affectsConfiguration(`${section}.${key}`))
-          // @ts-expect-error internal function
-          configRefs[key]._set(newWorkspaceConfig.get(key))
+          configRefs[key].value = newWorkspaceConfig.get(key) as any
       }
     }))
   })

--- a/packages/core/src/utils/defineConfigs.ts
+++ b/packages/core/src/utils/defineConfigs.ts
@@ -7,6 +7,11 @@ import { onActivate } from './onActivate'
 import type { Nullable } from './types'
 
 export interface ConfigRef<T> extends WritableComputedRef<T> {
+  /**
+   * Write the configuration value to the workspace.
+   *
+   * @see https://code.visualstudio.com/api/references/vscode-api#WorkspaceConfiguration.update
+   */
   update: (value: T, configurationTarget?: ConfigurationTarget | boolean | null, overrideInLanguage?: boolean) => Promise<void>
 }
 
@@ -37,7 +42,7 @@ type ParseConfigType<C extends ConfigTypeRaw<any>> =
  * @internal
  */
 export type ParseConfigTypeOptions<C extends ConfigTypeOptions> = {
-  [K in keyof C]: ParseConfigType<C[K]>
+  -readonly [K in keyof C]: ParseConfigType<C[K]>
 }
 
 type ToConfigRefs<C extends object> = {

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './createKeyedComposable'
 export * from './createSingletonComposable'
+export * from './defineConfigObject'
 export * from './defineConfigs'
 export * from './defineExtension'
 export * from './defineLogger'

--- a/test/utils/defineConfigObject.test.ts
+++ b/test/utils/defineConfigObject.test.ts
@@ -1,0 +1,13 @@
+import { describe, expectTypeOf, it } from 'vitest'
+import { defineConfigObject } from 'reactive-vscode'
+
+describe('keyedComposable', () => {
+  it.skip('should have correct type', () => {
+    const config = defineConfigObject('test', {
+      num: 1,
+      obj: { a: 1 },
+    })
+    expectTypeOf(config.num).toMatchTypeOf<number>()
+    expectTypeOf(config.obj).toMatchTypeOf<{ a: number }>()
+  })
+})

--- a/test/utils/defineConfigObject.test.ts
+++ b/test/utils/defineConfigObject.test.ts
@@ -1,13 +1,21 @@
 import { describe, expectTypeOf, it } from 'vitest'
+import type { ConfigType } from 'reactive-vscode'
 import { defineConfigObject } from 'reactive-vscode'
 
 describe('keyedComposable', () => {
   it.skip('should have correct type', () => {
-    const config = defineConfigObject('test', {
+    const config1 = defineConfigObject('test', {
+      num: Number,
+      obj: Object as ConfigType<{ a: number }>,
+    })
+    expectTypeOf(config1.num).toMatchTypeOf<number>()
+    expectTypeOf(config1.obj).toMatchTypeOf<{ a: number }>()
+
+    const config2 = defineConfigObject('test', {
       num: 1,
       obj: { a: 1 },
     })
-    expectTypeOf(config.num).toMatchTypeOf<number>()
-    expectTypeOf(config.obj).toMatchTypeOf<{ a: number }>()
+    expectTypeOf(config2.num).toMatchTypeOf<number>()
+    expectTypeOf(config2.obj).toMatchTypeOf<{ a: number }>()
   })
 })

--- a/test/utils/defineConfigs.test.ts
+++ b/test/utils/defineConfigs.test.ts
@@ -6,40 +6,34 @@ describe('keyedComposable', () => {
   it.skip('should have correct type', () => {
     expectTypeOf(
       defineConfigs('test', {
-        str1: 'string',
-        str2: String,
-        num1: 'number',
-        num2: Number,
-        bool1: 'boolean',
-        bool2: Boolean,
-        null1: 'null',
-        null2: null,
-        int1: 'integer',
-        arr1: 'array',
-        arr2: Array,
-        obj1: 'object',
-        obj3: Object as ConfigType<{ a: number }>,
-        union1: ['string', 'number'],
-        union2: [String, Number],
-        union3: [String, Number, 'boolean'],
+        str: String,
+        num: Number,
+        bool: Boolean,
+        null: null,
+        arr: Array,
+        obj: Object as ConfigType<{ a: number }>,
+        union: [String, Number],
       }),
     ).toMatchTypeOf<{
-      str1: ConfigRef<string>
-      str2: ConfigRef<string>
-      num1: ConfigRef<number>
-      num2: ConfigRef<number>
-      bool1: ConfigRef<boolean>
-      bool2: ConfigRef<boolean>
-      null1: ConfigRef<null>
-      null2: ConfigRef<null>
-      int1: ConfigRef<number>
-      arr1: ConfigRef<any[]>
-      arr2: ConfigRef<any[]>
-      obj1: ConfigRef<Record<string | number, any>>
-      obj3: ConfigRef<{ a: number }>
-      union1: ConfigRef<string | number>
-      union2: ConfigRef<string | number>
-      union3: ConfigRef<string | number | boolean>
+      str: ConfigRef<string>
+      num: ConfigRef<number>
+      bool: ConfigRef<boolean>
+      null: ConfigRef<null>
+      arr: ConfigRef<any[]>
+      obj: ConfigRef<{ a: number }>
+      union: ConfigRef<string | number>
+    }>()
+
+    expectTypeOf(
+      defineConfigs('test', {
+        num: 1,
+        obj: { a: 1 },
+      }),
+    ).toMatchTypeOf<{
+      num: ConfigRef<number>
+      obj: ConfigRef<{
+        a: number
+      }>
     }>()
   })
 })


### PR DESCRIPTION
This would allow this lib to work with `vscode-ext-gen` like:

```ts
import { defineConfigsWithDefaults, reactive, ref } from 'reactive-vscode'
import { scopedConfigs, ScopedConfigKeyTypeMap } from './generated-meta'

export const config = reactive(
  defineConfigsWithDefaults<ScopedConfigKeyTypeMap>(
    scopedConfigs.scope,
    scopedConfigs.defaults,
  )
)
```

Supporting write-back for ref makes it more like a ref; otherwise, we could have a `readonly` version that would disallow that. But in general, when we want to wrap it with `reactive, ' I think being able to write back would make the DX better in those cases.