### PR TITLE
fix: do not mark config types as internal

### DIFF
--- a/packages/core/src/utils/defineConfigs.ts
+++ b/packages/core/src/utils/defineConfigs.ts
@@ -26,9 +26,6 @@ export interface ConfigType<T> extends ObjectConstructor {
 type ConfigTypeSingle<T> = typeof String | typeof Number | typeof Boolean | typeof Array | typeof Object | null | ConfigType<T>
 type ConfigTypeRaw<T> = ConfigTypeSingle<T> | ConfigTypeSingle<T>[]
 
-/**
- * @internal
- */
 export type ConfigTypeOptions = Record<string, ConfigTypeRaw<any>>
 
 type ParseConfigType<C extends ConfigTypeRaw<any>> =
@@ -42,9 +39,6 @@ type ParseConfigType<C extends ConfigTypeRaw<any>> =
                 C extends null ? null : never
     )
 
-/**
- * @internal
- */
 export type ParseConfigTypeOptions<C extends ConfigTypeOptions> = {
   -readonly [K in keyof C]: ParseConfigType<C[K]>
 }


### PR DESCRIPTION
I got type error with beta.5 because those types get removed in the final .d.ts:

<img width="1206" alt="Screenshot 2024-07-16 at 12 29 08" src="https://github.com/user-attachments/assets/a2d8777c-b64d-4a70-a4a4-d62b832852ab">

<img width="1185" alt="Screenshot 2024-07-16 at 12 29 42" src="https://github.com/user-attachments/assets/bfd0a307-6615-40e5-bc1b-6d16d13e89d1">
