### PR TITLE
docs: fix typos and add missing documentation

### DIFF
--- a/docs/guide/command.md
+++ b/docs/guide/command.md
@@ -2,7 +2,7 @@
 
 Commands trigger actions. Commands expose functionality to users, bind to actions in VS Code's UI, and implement internal logic.
 
-There are some [built-in commands](https://code.visualstudio.com/api/references/commands) in VS Code, and you can also define your own commands.
+There are some [built-in commands](https://code.visualstudio.com/api/references/commands) in VSCode, and you can also define your own commands.
 
 ## Define in Manifest <NonProprietary />
 

--- a/docs/guide/context.md
+++ b/docs/guide/context.md
@@ -16,4 +16,4 @@ export = defineExtension(() => {
 
 Note that `contextA` and `contextB` are `ref`s, which means you can set them later, and the context will be updated accordingly. `contextC` is a `computed` value, which means it will be updated automatically when `contextA` changes.
 
-For more information about when clause contexts, please refer to the [official documentation](https://code.visualstudio.com/api/references/when-clause-contexts).
+For more information on `when` clause contexts, please refer to the [official documentation](https://code.visualstudio.com/api/references/when-clause-contexts).

--- a/docs/guide/disposable.md
+++ b/docs/guide/disposable.md
@@ -1,8 +1,8 @@
 # Disposables
 
-Although most of the VSCode API is covered by <ReactiveVscode />, sometimes you still need to work with `vscode::Disposable`, which is also described in [VSCode API Patterns](https://code.visualstudio.com/api/references/vscode-api#disposables).
+Although most of the VSCode APIs are covered by <ReactiveVscode />, sometimes you still need to work with `vscode::Disposable`, which is also described in [VSCode API Patterns](https://code.visualstudio.com/api/references/vscode-api#disposables).
 
-`reactive::useDisposable` accepts a disposable object and automatically disposes it when the current effect scope is disposed (e.g., when the extension is deactivated, if `vscode::useDisposable` is called in the extension's setup function). `reactive::useDisposable` returns the disposable object itself as is.
+`reactive::useDisposable` accepts a disposable object and automatically disposes it when the current effect scope is disposed (e.g When the extension is deactivated, if `vscode::useDisposable` is called in the extension's setup function). `reactive::useDisposable` returns the disposable object itself as is.
 
 ```ts
 import type { TextDocument } from 'vscode'
@@ -21,4 +21,4 @@ export = defineExtension(() => {
 })
 ```
 
-Note that you needn't to use `reactive::useDisposable` for disposables created by any <ReactiveVscode /> functions. They are automatically disposed when the current effect scope is disposed.
+Note that you don't need to use `reactive::useDisposable` for disposables created by any <ReactiveVscode /> functions. They are automatically disposed when the current effect scope is disposed.

--- a/docs/guide/editor.md
+++ b/docs/guide/editor.md
@@ -1,5 +1,12 @@
+# Editor and Document
+
+## Document
+
+The `reactive::useDocumentText` composable can be used to get the text of the document.
+
+```ts
 import type { ExtensionContext } from 'vscode'
-/* eslint-disable import/first */
+
 import { computed, defineExtension, ref, useActiveTextEditor, useDocumentText, watchEffect } from 'reactive-vscode'
 
 export = defineExtension(() => {
@@ -36,7 +43,7 @@ See `vscode::TextEditor.setDecorations` for more information. To create a decora
 
 ## Editor Selections
 
-The following 4 composable can be used to **get and set** the selections of editors.
+The following 4 composables can be used to **get and set** the selections of editors.
 
 - `reactive::useTextEditorSelections` - All selections in the text editor.
 - `reactive::useTextEditorSelection` - The primary selection in the text editor.
@@ -47,7 +54,7 @@ See their docs for more information. Note that `reactive::useTextEditorSelection
 
 ## Editor Viewport
 
-The following 3 composable can be used to **get** the viewport information of editors.
+The following 3 composables can be used to **get** the viewport information of editors.
 
 - `reactive::useTextEditorViewColumn` - The view column of the text editor.
 - `reactive::useTextEditorVisibleRanges` - The visible ranges of the text editor.

--- a/docs/guide/event.md
+++ b/docs/guide/event.md
@@ -1,8 +1,8 @@
 # Events
 
-Although most of the VSCode API is covered by <ReactiveVscode />, sometimes you still need to create or listen original [VSCode events](https://code.visualstudio.com/api/references/vscode-api#events).
+Although most of the VSCode APIs are covered by <ReactiveVscode />, sometimes you still need to create or listen to the primitive  [VSCode events](https://code.visualstudio.com/api/references/vscode-api#events).
 
-`reactive::useEvent` converts an raw event to a auto-disposed event:
+`reactive::useEvent` converts a raw event to an auto-disposed event:
 
 ```ts
 import { defineExtension, useEvent } from 'reactive-vscode'
@@ -18,7 +18,7 @@ export = defineExtension(() => {
 })
 ```
 
-`reactive::useEventEmitter` creates a frindly event emitter, which still extends `vscode::EventEmitter`:
+`reactive::useEventEmitter` creates a friendly event emitter which still extends `vscode::EventEmitter`:
 
 <!-- eslint-disable import/first -->
 ```ts

--- a/docs/guide/view.md
+++ b/docs/guide/view.md
@@ -56,7 +56,7 @@ export = defineExtension(() => {
 })
 ```
 
-The `children` property in nodes is used to define the children of the node. The `treeItem` propert is required and is used to define the tree item of the node. It should be a `vscode::TreeItem` object, or a promise that resolves to a `vscode::TreeItem` object.
+The `children` property in nodes is used to define the children of the node. The `treeItem` property is required and is used to define the tree item of the node. It should be a `vscode::TreeItem` object, or a promise that resolves to a `vscode::TreeItem` object.
 
 If you want to trigger an update based on some reactive values that aren't tracked in `treeData`, you can pass them to the `watchSource` option.
 
@@ -65,7 +65,7 @@ If you want to trigger an update based on some reactive values that aren't track
 :::
 
 ::: warning
-For the above example, `useDemoTreeView` should **not** be called top-level in the module, because the extension context is not available at that time. Instead, you should **always** call it in the `setup` function.
+For the above example, `useDemoTreeView` should **not** be called at the top-level in the module, because the extension context is not available at that time. Instead, you should **always** call it in the `setup` function.
 :::
 
 ## Register Webview

--- a/docs/guide/vueuse.md
+++ b/docs/guide/vueuse.md
@@ -37,4 +37,4 @@ export = defineExtension(() => {
 
 ## Available Functions
 
-Every VueUse function that is compatible with the Node.js environment and doesn't require Vue's rendering API is available in this package. Check out [`packages/vueuse/src/index.ts`](https://github.com/KermanX/reactive-vscode/blob/main/packages/vueuse/src/index.ts) for the full list.
+Every VueUse function that is compatible with the Node.js environment and doesn't require Vue's rendering API is available in this package. Check it out [`packages/vueuse/src/index.ts`](https://github.com/KermanX/reactive-vscode/blob/main/packages/vueuse/src/index.ts) for the full list.

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -16,11 +16,11 @@ The official API is event-based, which means you have to listen to events to wat
 
 ### The Disposables
 
-Disposables are everywhere in a VSCode extension. You have to store all of them to `vscode::ExtensionContext.subscriptions`, or dispose them manually.
+Disposables are everywhere in a VSCode extension. You have to store all of them in `vscode::ExtensionContext.subscriptions`, or dispose them manually.
 
 ### When to Initialize
 
-Views in a VSCode extension are created lazily. If you want to access a view instance, you have to store it, and even listen to a event which is fired when the view is created.
+Views in a VSCode extension are created lazily. If you want to access a view instance, you have to store it, and even listen to an event which is fired when the view is created.
 
 ### Want to use Vue
 

--- a/docs/guide/window.md
+++ b/docs/guide/window.md
@@ -79,4 +79,4 @@ export = defineExtension(() => {
 })
 ```
 
-Note that you can pass one of an array of patterns to watch for changes in the file system. Multiple VSCode watchers are created for each pattern.
+Note that you can pass an array of patterns to watch for changes in the file system. Multiple VSCode watchers will be created for each pattern.

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ features:
     details: Most of the VSCode APIs included
   - icon: ⚡
     title: Fully tree shakeable
-    details: Only take what you want
+    details: Only use what you want
   - icon: <span class="i-logos-vueuse"></span>
     title: VueUse Integration
     details: A Collection of Vue composition utilities

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ features:
     details: Most of the VSCode APIs included
   - icon: ⚡
     title: Fully tree shakeable
-    details: Only use what you want
+    details: Only take what you want
   - icon: <span class="i-logos-vueuse"></span>
     title: VueUse Integration
     details: A Collection of Vue composition utilities


### PR DESCRIPTION
This pull request is intended to do three things namely:

1. Fix typographical errors that are found in the documentation.
2. Add missing documentation about the `useDocumentText` composable.
3. Fix the code display on the `useDocumentText` composable usage.