### PR TITLE
feat: support reactive `decorationTypeOrOptions`

### DIFF
--- a/packages/core/src/composables/useActiveEditorDecorations.ts
+++ b/packages/core/src/composables/useActiveEditorDecorations.ts
@@ -9,7 +9,7 @@ import { useEditorDecorations } from './useEditorDecorations'
  * @category editor
  */
 export function useActiveEditorDecorations(
-  decorationTypeOrOptions: TextEditorDecorationType | DecorationRenderOptions,
+  decorationTypeOrOptions: MaybeRefOrGetter<TextEditorDecorationType | DecorationRenderOptions>,
   rangesOrOptions: MaybeRefOrGetter<readonly Range[] | readonly DecorationOptions[]>,
 ) {
   const activeEditor = useActiveTextEditor()


### PR DESCRIPTION
Currently `useEditorDecorations` does not support reactive `decorationTypeOrOptions`. 

Why I need it:  
In my [extension](https://github.com/howcasperwhat/comment-formula), I will match some content/code in the document (just like what unocss and iconify do), and I allow users to change [style](https://github.com/howcasperwhat/comment-formula/blob/main/src/annotation.ts#L28) of the matched content/code. So I should `watch` the configuration and reactively change styles of the decoration which only can set once when calling `window.createTextEditorDecorationType`.