### PR TITLE
fix(creator): correct markdown syntax in `README` template

### DIFF
--- a/packages/creator/templates/readme.ts
+++ b/packages/creator/templates/readme.ts
@@ -1,6 +1,6 @@
 export default (publisher: string, identifier: string, displayName: string) => `# ${displayName}
 
-[![Version](https://img.shields.io/visual-studio-marketplace/v/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Installs](https://img.shields.io/visual-studio-marketplace/i/${publisher}.${identifier}](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Reactive VSCode](https://img.shields.io/badge/Reactive-VSCode-%23007ACC?style=flat&labelColor=%23229863)](https://kermanx.github.io/reactive-vscode/)
+[![Version](https://img.shields.io/visual-studio-marketplace/v/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Installs](https://img.shields.io/visual-studio-marketplace/i/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Reactive VSCode](https://img.shields.io/badge/Reactive-VSCode-%23007ACC?style=flat&labelColor=%23229863)](https://kermanx.github.io/reactive-vscode/)
 
 A VS Code extension created with [Reactive VS Code](https://kermanx.github.io/reactive-vscode/).
 


### PR DESCRIPTION
This PR fixes incorrect markdown syntax in the `README` template, specifically in the badge section. 

### Changes Made

- Fixed a missing closing `)` in the second badge link, which caused the markdown to render incorrectly.

### Before

[![Version](https://img.shields.io/visual-studio-marketplace/v/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Installs](https://img.shields.io/visual-studio-marketplace/i/${publisher}.${identifier}](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Reactive VSCode](https://img.shields.io/badge/Reactive-VSCode-%23007ACC?style=flat&labelColor=%23229863)](https://kermanx.github.io/reactive-vscode/)


### After

[![Version](https://img.shields.io/visual-studio-marketplace/v/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Installs](https://img.shields.io/visual-studio-marketplace/i/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Reactive VSCode](https://img.shields.io/badge/Reactive-VSCode-%23007ACC?style=flat&labelColor=%23229863)](https://kermanx.github.io/reactive-vscode/)