### PR TITLE
fix(docs): set width and height for the reactive-vscode logo icon to display it

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -104,6 +104,14 @@ export default defineConfig({
                 logo: () => readFile(resolve(__dirname, '../public/logo.svg'), 'utf-8'),
               },
             },
+            customizations: {
+              iconCustomizer(collection, icon, props) {
+                if (collection === 'reactive-vscode' && icon === 'logo') {
+                  props.width = '1em'
+                  props.height = '1em'
+                }
+              },
+            },
           }),
         ],
         theme: {


### PR DESCRIPTION
Hi! 👋 

I was browsing the [documentation](https://kermanx.com/reactive-vscode/guide/) and noticed that some of the API links seemed to have too much left padding. Actually, the `reactive-vscode` logo icon wasn't showing up because it had invalid width and height, which came from the respective attributes in the original SVG.

This PR fixes the height and width of this icon so that it displays like the others. Thanks!

## Screenshots

### Before

<img width="1470" height="922" alt="" src="https://github.com/user-attachments/assets/68169701-7258-42b3-b287-a82eb490c823" />

### After

<img width="1470" height="922" alt="" src="https://github.com/user-attachments/assets/cf40ef60-418d-491e-8f42-e3f652f08f0d" />

## References

- https://unocss.dev/presets/icons#icon-collection-customization