### PR TITLE
fix: update the deprecated VS Marketplace Shields.io badges to Badgen ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 
 Currently, most of the VSCode APIs are covered, and this project has been used in:
 
-- [Vue - Official <sub><sub>![downloads](https://img.shields.io/visual-studio-marketplace/d/Vue.volar.svg)</sub></sub>](https://github.com/vuejs/language-tools)
-- [Slidev for VSCode <sub><sub>![downloads](https://img.shields.io/visual-studio-marketplace/d/antfu.slidev.svg)</sub></sub>](https://github.com/slidevjs/slidev/tree/main/packages/vscode)
-- [Iconify IntelliSense <sub><sub>![downloads](https://img.shields.io/visual-studio-marketplace/d/antfu.iconify.svg)</sub></sub>](https://github.com/antfu/vscode-iconify)
+- [Vue - Official <sub><sub>![downloads](https://badgen.net/vs-marketplace/d/Vue.volar)</sub></sub>](https://github.com/vuejs/language-tools)
+- [Slidev for VSCode <sub><sub>![downloads](https://badgen.net/vs-marketplace/d/antfu.slidev)</sub></sub>](https://github.com/slidevjs/slidev/tree/main/packages/vscode)
+- [Iconify IntelliSense <sub><sub>![downloads](https://badgen.net/vs-marketplace/d/antfu.iconify)</sub></sub>](https://github.com/antfu/vscode-iconify)
 
 The [documentation](https://kermanx.com/reactive-vscode/) is complete, and the [VueUse integration](https://kermanx.com/reactive-vscode/guide/vueuse.html) is also available.
 

--- a/packages/creator/templates/readme.ts
+++ b/packages/creator/templates/readme.ts
@@ -1,6 +1,6 @@
 export default (publisher: string, identifier: string, displayName: string) => `# ${displayName}
 
-[![Version](https://img.shields.io/visual-studio-marketplace/v/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Installs](https://img.shields.io/visual-studio-marketplace/i/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Reactive VSCode](https://img.shields.io/badge/made_with-reactive--vscode-%23007ACC?style=flat&labelColor=%23229863)](https://kermanx.com/reactive-vscode/)
+[![Version](https://badgen.net/vs-marketplace/v/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Installs](https://badgen.net/vs-marketplace/i/${publisher}.${identifier})](https://marketplace.visualstudio.com/items?itemName=${publisher}.${identifier}) [![Reactive VSCode](https://img.shields.io/badge/made_with-reactive--vscode-%23007ACC?style=flat&labelColor=%23229863)](https://kermanx.com/reactive-vscode/)
 
 A VS Code extension created with [reactive-vscode](https://kermanx.com/reactive-vscode/).
 
@@ -13,7 +13,7 @@ A VS Code extension created with [reactive-vscode](https://kermanx.com/reactive-
 
 - Open this repository in VS Code.
 - Run \`pnpm install\` to install the dependencies.
-- Run \`pnpm dev\` to compile the extension and watch for changes.  
+- Run \`pnpm dev\` to compile the extension and watch for changes.
 - Press \`F5\` to open a new window with your extension loaded.
 - Run your command from the command palette by pressing (\`Ctrl+Shift+P\` or \`Cmd+Shift+P\` on Mac) and typing \`Hello World\`.
 - Set breakpoints in your code inside \`src/extension.ts\` to debug your extension.


### PR DESCRIPTION
Hi! 👋 

The [VS Marketplace Shields.io badges have been deprecated](https://github.com/badges/shields/pull/11792) and are [no longer showing the expected values](https://github.com/kermanx/reactive-vscode/blob/41b9ea000e0e7afd74654c707c62ef8db62b3f94/README.md#project-status). This PR switches them over to [Badgen](https://badgen.net/), a similar service that's under [active development.](https://github.com/badgen/badgen.net) I also [looked into VSMarketplaceBadges](https://github.com/PowerShell/vscode-powershell/pull/5480), but it hasn't been updated in [4 years](https://github.com/cssho/VSMarketplaceBadges), so I figured Badgen would be a better bet.

Thanks!