### PR TITLE
fix(deps): pin @types/vscode to patch version

### DIFF
--- a/packages/creator/templates/package.ts
+++ b/packages/creator/templates/package.ts
@@ -41,7 +41,7 @@ export default (publisher: string, identifier: string, displayName: string, core
   },
   "devDependencies": {
     "@types/node": "22.x",
-    "@types/vscode": "^1.99.0",
+    "@types/vscode": "~1.99.0",
     "reactive-vscode": "${coreVersion}",
     "tsdown": "^0.15.11",
     "typescript": "^5.9.3"


### PR DESCRIPTION
> 一个非常小的改动，感谢您开源了一个优秀的框架

## 参考
https://github.com/material-extensions/vscode-material-icon-theme/blob/main/package.json （~）
https://github.com/vuejs/language-tools/blob/master/extensions/vscode/package.json （写死版本）

## 为什么把 `^` 改成 `~`？

| 符号 | 含义 | 允许更新的版本 |
|------|------|--------------|
| `^1.99.0` | 兼容版本 | `1.100.0`、`1.101.0`、… 甚至 `1.200.0` |
| `~1.99.0` | 近似版本 | 仅限 `1.99.1`、`1.99.2` 等 patch 更新 |

### 核心原因：**VS Code 的 API 类型在 minor 版本里可能包含破坏性变更**

`@types/vscode` 跟随 VS Code 本身的版本发布。VS Code 的 minor 版本更新（比如 `1.100.0`）经常会：

- **新增 API** — 这本身没问题
- **修改现有 API 的类型定义** — 比如把某个参数从可选改成必填，或者调整返回值类型

这些类型层面的改动对你的扩展代码来说可能就是**编译错误**，即使 VS Code 运行时本身向下兼容。

### 举个例子

假设你开发的扩展声明支持 VS Code `^1.99.0`：

- 用户环境实际运行的是 `1.99.x` ✅ 没问题
- 但你的开发环境 `npm install` 时可能拉下来 `1.105.0`
- 如果 `1.105.0` 里某个 API 的类型变了，你的代码可能**编译不过**
- 更隐蔽的是：你本地编译通过了，但用户实际运行的 `1.99.x` 上**行为不一致**

### `~1.99.0` 的好处

1. **确定性**：锁定在 `1.99.x` 范围内，类型定义稳定
2. **可预测**：升级 `@types/vscode` 是**显式决策**，而不是每次 `npm install` 的意外
3. **与 `engines.vscode` 对齐**：通常 `package.json` 里会有 `"vscode": "^1.99.0"` 声明运行时兼容范围，而 `@types/vscode` 用 `~` 确保开发时类型精确匹配
